### PR TITLE
Fix install of requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ git clone https://github.com/chris-greening/instascrape.git
 ```
 > and install required dependencies using 
 ```shell
-$ pip3 install -f requirements.txt
+$ pip3 install -r requirements.txt
 ```
 
 ---


### PR DESCRIPTION
Use '-r' flag instead of '-f' flag

Thanks for contributing to instascrape! Please review and fill out the checklist below before submitting your request. 

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Additional Notes 
Feel free to include any additional information regarding your PR below: 
Just noticed a slight mistype while going through the readme. Figured it'd be good to submit a PR for it (not for Hacktoberfest).

pip install -f requirements.txt failed for me with `ERROR: You must give at least one requirement to install (maybe you meant "pip install requirements.txt"?)`
