### PR TITLE
fix: fixed conversion to upload_date to check if timestamp is present

### DIFF
--- a/instascrape/scrapers/post.py
+++ b/instascrape/scrapers/post.py
@@ -65,8 +65,12 @@ class Post(_StaticHtmlScraper):
             self.source = self.shortcode
         super().scrape(mapping=mapping, keys=keys, exclude=exclude)
 
-        if mapping is None:
+        #HACK: This isn't a very clean solution and there is certainly a better
+        # way to deal with returning a Post object with only partial data
+        if hasattr(self, "timestamp"):
             self.upload_date = datetime.datetime.fromtimestamp(self.timestamp)
+
+        if mapping is None:
             self.tagged_users = self._parse_tagged_users(self.json_dict)
             self.hashtags = self._parse_hashtags(self.caption)
             try:


### PR DESCRIPTION
Thanks for contributing to instascrape! Please review and fill out the checklist below before submitting your request. 

Fixed missing `upload_date` from `timestamp` attribute conversion after returning `Post`s objects from `Profile.get_recent_posts` instance method. 

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

