### PR TITLE
[Fix] Wrong biography when passing sessionid

### DIFF
--- a/instascrape/core/_static_scraper.py
+++ b/instascrape/core/_static_scraper.py
@@ -144,11 +144,14 @@ class _StaticHtmlScraper(ABC):
             return_data = self._get_json_from_source(self.source, headers=headers, session=session)
             flat_json_dict = flatten_dict(return_data["json_dict"])
 
-            #HACK: patch mapping to fix the profile pic scrape when a sessionid is present
+            # HACK: patch mapping to fix the profile pic and biography scrape when a sessionid is present
+            # When a sessionid is present we should map to the corresponding "user_***" key
+            # Example: "biography" should be mapped to "user_biography"
             try:
                 if "sessionid" in headers["cookie"]:
                     mapping["profile_pic_url"] = deque(["user_profile_pic_url"])
                     mapping["profile_pic_url_hd"] = deque(["user_profile_pic_url_hd"])
+                    mapping["biography"] = deque(["user_biography"])
             except KeyError:
                 pass
 


### PR DESCRIPTION
## Description
When a **sessionid** is passed to the `Profile.scrape()` function, the scraped profile contains a wrong biography.  
Instead of getting the biography of the Profile asked, it returns the biography of the account associated to the **sessionid** (the "viewer user").

The fix maps the key `biography` to `user_biography`. This fix is similar to the `profile_pic_url `and `user_profile_pic_url `keys.  
This is needed because Instagram returns different keys when logged in using a **sessionid** cookie. The right keys are the same but preceded by `user_`

Closes #88

## Checklist

* [x] I followed the guidelines in our Contributing document
* [x] I added an explanation of my changes
* [ ] I have written new tests for my changes, as applicable
* [x] I successfully ran tests with my changes locally

