### PR TITLE
Add download_carousel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,9 +129,6 @@ dmypy.json
 .pyre/
 
 .idea/
-<<<<<<< HEAD
 
 # Large file ignores
 tutorial/examples/Donald\ Trump/*.db*
-=======
->>>>>>> aa8b12067d01e19fb94af91be18f49d8042feeac

--- a/instascrape/scrapers/post.py
+++ b/instascrape/scrapers/post.py
@@ -228,9 +228,17 @@ class Post(_StaticHtmlScraper):
         comments_arr : List[Comment]
             List of Comment objects
         """
-        list_of_dicts = self.json_dict["entry_data"]["PostPage"][0]["graphql"]["shortcode_media"][
-            "edge_media_to_parent_comment"
-        ]["edges"]
+        # HACK:
+        # The JSON is structured differently if the scrape is performed using a
+        # WebDriver or Session.
+        try:
+            list_of_dicts = self.json_dict["entry_data"]["PostPage"][0]["graphql"]["shortcode_media"][
+                "edge_media_to_parent_comment"
+            ]["edges"]
+        except KeyError:
+            list_of_dicts = self.json_dict["graphql"]["shortcode_media"][
+                "edge_media_to_parent_comment"
+            ]["edges"]
         comments_arr = [Comment(comment_dict) for comment_dict in list_of_dicts]
         return comments_arr
 

--- a/instascrape/scrapers/profile.py
+++ b/instascrape/scrapers/profile.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import time
 
-from typing import List
+from itertools import islice
+from typing import List, Union, Iterable
 
 from bs4 import BeautifulSoup
 
@@ -54,9 +55,117 @@ class Profile(_StaticHtmlScraper):
             posts.append(post)
         return posts
 
+    def iter_posts(self, webdriver, login_first=False, login_pause=60, max_failed_scroll=300,
+                   scroll_pause=0, force_reload=False) -> Iterable[Post]:
+        """
+        Return an iterator yielding Post objects from profile scraped using a
+        webdriver (not included). Use this to lazily load recent posts from
+        accounts with large post counts, saving time and reducing network
+        usage.
+
+        Does not limit posts or detect whether all posts have been returned;
+        you can control this behavior easily by wrapping the returned iterator
+        in `itertools.islice` and using the number of posts by this account,
+        `self.posts`, to place an upper limit (though the iterator will exit
+        gracefully on timeout, so you don't have to worry about it permanently
+        hanging).
+
+        *NOTE that when using Selenium webdrivers to scrape posts, you'll want
+        to open a new tab to avoid trashing iterator state if you're sharing
+        the webdriver with both the iterator returned by this method and the
+        post scrapers.*
+
+        Parameters
+        ----------
+        webdriver : selenium.webdriver.chrome.webdriver.WebDriver
+            Selenium webdriver for rendering JavaScript and loading dynamic
+            content
+        login_first : bool
+            Start on login page to allow user to manually login to Instagram
+        login_pause : int
+            Length of time in seconds to pause before starting scrape
+        max_failed_scroll : int
+            Maximum amount of scroll attempts before stopping if scroll is stuck
+        scroll_pause : Union[int, Iterable[int]]
+            Milliseconds to wait between scroll attempts (in case you want to
+            reduce your request rate). Optionally provide an iterator returning
+            ints if you'd like to e.g. randomize the delay times.
+        force_reload : bool
+            If True, reload the page even if it is already open. This will
+            destroy scroll state, potentially harming performance if the
+            profile is already loaded, but will ensure a more consistent state
+            for each attempt.
+
+        Returns
+        -------
+        posts : Iterable[Post]
+            Generator of post objects gathered from the profile page
+
+        See Also
+        --------
+        Profile.get_posts
+            A synchronous version of this function.
+        """
+
+        JS_SCROLL_SCRIPT = "window.scrollTo(0, document.body.scrollHeight); var lenOfPage=document.body.scrollHeight; return lenOfPage;"
+        JS_PAGE_LENGTH_SCRIPT = "var lenOfPage=document.body.scrollHeight; return lenOfPage;"
+
+        # Get a delay iterator if given a const
+        if not isinstance(scroll_pause, Iterable):
+            def delay(i):
+                while True:
+                    yield i
+            scroll_pause = delay(scroll_pause)
+
+        # Determine how many posts are available on the page
+        try:
+            posts_len = self.posts
+        except AttributeError:
+            raise AttributeError(f"{type(self)} must be scraped first")
+
+        # Manual login
+        if login_first:
+            webdriver.get("https://www.instagram.com")
+            time.sleep(login_pause)
+
+        # Get profile page if not already active (avoid unnecessary reloads)
+        if force_reload or webdriver.current_url != self.url:
+            webdriver.get(self.url)
+
+        # Continuously scroll, collect HTML, and yield parsed Post objects
+        shortcodes = set()
+        scroll_attempts = 0
+        last_position = webdriver.execute_script(JS_PAGE_LENGTH_SCRIPT)
+        while True:
+            current_position = webdriver.execute_script(JS_SCROLL_SCRIPT)
+            source_data = webdriver.page_source
+            found_posts = self._separate_posts(source_data)
+
+            # Yield posts that have not already been found
+            for post in found_posts:
+                if post.source not in shortcodes:
+                    shortcodes.add(post.source)
+                    yield post
+
+            # If scroll is stuck and exceeds max allowed attempts, exit loop
+            time.sleep(next(scroll_pause)*1e-3)
+            if current_position == last_position:
+                scroll_attempts += 1
+                if scroll_attempts > max_failed_scroll:
+                    break
+            else:
+                scroll_attempts = 0
+                last_position = current_position
+
     def get_posts(self, webdriver, amount=None, login_first=False, login_pause=60, max_failed_scroll=300, scrape=False, scrape_pause=5):
         """
-        Return Post objects from profile scraped using a webdriver (not included)
+        Return Post objects from profile scraped using a webdriver (not included).
+
+        It is *highly recommended* that you use the lazy iterator form of this
+        call, `iter_posts`, which will be much faster and much gentler on
+        network resources when iterating through large accounts, particularly
+        when you need to decide how many posts are needed based on the posts
+        themselves. That method will always be at least as fast as this one.
 
         Parameters
         ----------
@@ -80,10 +189,13 @@ class Profile(_StaticHtmlScraper):
         -------
         posts : List[Post]
             Post objects gathered from the profile page
-        """
 
-        JS_SCROLL_SCRIPT = "window.scrollTo(0, document.body.scrollHeight); var lenOfPage=document.body.scrollHeight; return lenOfPage;"
-        JS_PAGE_LENGTH_SCRIPT = "var lenOfPage=document.body.scrollHeight; return lenOfPage;"
+        See Also
+        --------
+        Profile.iter_posts
+            Lazy iterator version of this method. More flexible and performant,
+            *highly recommended over this one.*
+        """
 
         # Determine how many posts are available on the page
         try:
@@ -95,55 +207,13 @@ class Profile(_StaticHtmlScraper):
         except AttributeError:
             raise AttributeError(f"{type(self)} must be scraped first")
 
-        # Manual login
-        if login_first:
-            webdriver.get("https://www.instagram.com")
-            time.sleep(login_pause)
-
-        # Get profile page
-        webdriver.get(self.url)
-
-        # Continuously scroll, collect HTML, and parse Post objects
-        posts = []
-        shortcodes = []
-        scroll_attempts = 0
-        last_position = webdriver.execute_script(JS_PAGE_LENGTH_SCRIPT)
-        scrolling = True
-        while scrolling:
-            current_position = webdriver.execute_script(JS_SCROLL_SCRIPT)
-            source_data = webdriver.page_source
-            found_posts = self._separate_posts(source_data)
-
-            # Append found posts into total posts
-            for post in found_posts:
-                if post.source not in shortcodes:
-                    shortcodes.append(post.source)
-                    posts.append(post)
-
-            # If scroll is stuck and exceeds max allowed attempts, exit loop
-            if current_position == last_position:
-                scroll_attempts += 1
-                if scroll_attempts > max_failed_scroll:
-                    scrolling = False
-            else:
-                scroll_attempts = 0
-                last_position = current_position
-
-            current_post_len = len(posts)
-            if (current_post_len >= posts_len) or (current_post_len >= amount):
-                break
-
-        # Remove excess posts from right of list
-        posts = posts[:amount]
-
-        # If scrape arg is True, scrape all posts using webdriver
-        scraped_posts = []
+        # Eagerly collect the posts from an iterator
+        posts = [*islice(self.iter_posts(webdriver, login_first, login_pause,
+                                         max_failed_scroll, 0, True), amount)]
         if scrape:
             for post in posts:
-                scraped_posts.append(post.scrape(inplace=False, webdriver=webdriver))
+                post.scrape(inplace=True, webdriver=webdriver)
                 time.sleep(scrape_pause)
-            posts = scraped_posts
-
         return posts
 
     def _separate_posts(self, source_data):

--- a/tutorial/examples/download_recent_posts.ipynb
+++ b/tutorial/examples/download_recent_posts.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "import sys\n",
+    "from typing import Dict, List, Any, Tuple, Optional, Callable, Union\n",
+    "from urllib.parse import urlparse\n",
+    "from instascrape import Post, Profile\n",
+    "import requests\n",
+    "from selenium.webdriver.chrome.webdriver import WebDriver\n",
+    "from selenium.webdriver.chrome.options import Options\n",
+    "\n",
+    "\n",
+    "def setup(account, data_dir, login=False):\n",
+    "    chrome_options = Options()\n",
+    "    chrome_options.add_argument(f\"user-data-dir={data_dir}\")\n",
+    "    wd = WebDriver(options=chrome_options)\n",
+    "    if login:\n",
+    "        wd.get(\"https:/www.instagram.com\")\n",
+    "        input(\"Log in, then press `Enter` to continue...\")\n",
+    "    #s = requests.Session()\n",
+    "    #for cookie in wd.get_cookies():\n",
+    "    #    s.cookies.set(cookie['name'], cookie['value'])\n",
+    "    a = Profile(account)\n",
+    "    a.scrape(webdriver=wd)\n",
+    "    return wd, a"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Staying logged in\n",
+    "\n",
+    "Set the account you want to load as well as a place to persist your login state (so you can get around the stingy anonymous API rates). Set `login=True` to log in the first time; on subsequent runs, you shouldn't need to manually log in again (at least not for a little while)."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [],
+   "source": [
+    "wd, a = setup(act, usrdir, True)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [],
+   "source": [
+    "ps = a.get_posts(wd, amount=30, max_failed_scroll=10, scroll_pause=1000)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "30"
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(ps)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "outputs": [],
+   "source": [
+    "aps = a.iter_posts(wd, amount=30, max_failed_scroll=10, scroll_pause=1000)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[1;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[1;31mKeyboardInterrupt\u001B[0m                         Traceback (most recent call last)",
+      "\u001B[1;32m<ipython-input-8-24f1d881da78>\u001B[0m in \u001B[0;36m<module>\u001B[1;34m\u001B[0m\n\u001B[1;32m----> 1\u001B[1;33m \u001B[0mps2\u001B[0m \u001B[1;33m=\u001B[0m \u001B[1;33m[\u001B[0m\u001B[1;33m*\u001B[0m\u001B[0maps\u001B[0m\u001B[1;33m]\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0m",
+      "\u001B[1;32m~\\dev\\instascrape\\instascrape\\scrapers\\profile.py\u001B[0m in \u001B[0;36miter_posts\u001B[1;34m(self, webdriver, amount, login_first, login_pause, max_failed_scroll, scroll_pause, scrape, scrape_pause, force_reload)\u001B[0m\n\u001B[0;32m    148\u001B[0m \u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0;32m    149\u001B[0m             \u001B[1;31m# If scroll is stuck and exceeds max allowed attempts, exit loop\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[1;32m--> 150\u001B[1;33m             \u001B[0mtime\u001B[0m\u001B[1;33m.\u001B[0m\u001B[0msleep\u001B[0m\u001B[1;33m(\u001B[0m\u001B[0mnext\u001B[0m\u001B[1;33m(\u001B[0m\u001B[0mscroll_pause\u001B[0m\u001B[1;33m)\u001B[0m\u001B[1;33m*\u001B[0m\u001B[1;36m1e-3\u001B[0m\u001B[1;33m)\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0m\u001B[0;32m    151\u001B[0m             \u001B[1;32mif\u001B[0m \u001B[0mcurrent_position\u001B[0m \u001B[1;33m==\u001B[0m \u001B[0mlast_position\u001B[0m\u001B[1;33m:\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0;32m    152\u001B[0m                 \u001B[0mscroll_attempts\u001B[0m \u001B[1;33m+=\u001B[0m \u001B[1;36m1\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n",
+      "\u001B[1;31mKeyboardInterrupt\u001B[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "ps2 = [*aps]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'ps2' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[1;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[1;31mNameError\u001B[0m                                 Traceback (most recent call last)",
+      "\u001B[1;32m<ipython-input-9-cba80397f22f>\u001B[0m in \u001B[0;36m<module>\u001B[1;34m\u001B[0m\n\u001B[1;32m----> 1\u001B[1;33m \u001B[0mps2\u001B[0m\u001B[1;33m\u001B[0m\u001B[1;33m\u001B[0m\u001B[0m\n\u001B[0m",
+      "\u001B[1;31mNameError\u001B[0m: name 'ps2' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "ps2"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Post>"
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "next(aps)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Description

Commits fb0c968 and b51f725:

Adds a `download_carousel` method for `Post`s which allows you to download all media on carousel posts, i.e. posts with multiple images/videos, as raised in #105. Since this is a batch operation, you specify an output directory and a function for calculating the filename for each output image instead of specifying a single output filename. See the method documentation for details.

Also added a couple of supporting methods, though only one of them, `parse_carousel_urls`, is public; this method simply returns the video and image URLs for each image in the carousel, or `None` if the post is not a carousel. Again, see docstring for details.

Also added the beginnings of a demo jupyter notebook.

Fixes #105

Commit e88032e:

Post.get_recent_comments would raise a KeyError when using Selenium or a requests.Session object to scrape a Post due to slight differences in the structure of the resulting json_dict. I added an except block to handle this and try the alternative json_dict schema.

Fixes #124

Commit f443435:

Add `Profile.iter_posts` to get a lazy iterator over posts, and reimplement `Profile.get_posts` (with the same API) using `iter_posts`.

Fixes #127

## Checklist

* [x] I followed the guidelines in our Contributing document
* [x] I added an explanation of my changes
* [ ] I have written new tests for my changes, as applicable
* [ ] I successfully ran tests with my changes locally

## Additional notes (optional) 

**Have not written automated tests yet,** will do so soon.