### PR TITLE
fix get_recent_comments on selenium/requests.Session (Fixes #124)

### DIFF
--- a/instascrape/scrapers/post.py
+++ b/instascrape/scrapers/post.py
@@ -133,9 +133,17 @@ class Post(_StaticHtmlScraper):
         comments_arr : List[Comment]
             List of Comment objects
         """
-        list_of_dicts = self.json_dict["entry_data"]["PostPage"][0]["graphql"]["shortcode_media"][
-            "edge_media_to_parent_comment"
-        ]["edges"]
+        # HACK:
+        # The JSON is structured differently if the scrape is performed using a
+        # WebDriver or Session.
+        try:
+            list_of_dicts = self.json_dict["entry_data"]["PostPage"][0]["graphql"]["shortcode_media"][
+                "edge_media_to_parent_comment"
+            ]["edges"]
+        except KeyError:
+            list_of_dicts = self.json_dict["graphql"]["shortcode_media"][
+                "edge_media_to_parent_comment"
+            ]["edges"]
         comments_arr = [Comment(comment_dict) for comment_dict in list_of_dicts]
         return comments_arr
 


### PR DESCRIPTION
## Description

`Post.get_recent_comments` would raise a `KeyError` when using Selenium or a `requests.Session` object to scrape a `Post` due to slight differences in the structure of the resulting `json_dict`. I added an `except` block to handle this and try the alternative `json_dict` schema.

Fixes #124 

## Checklist

* [x] I followed the guidelines in our Contributing document
* [x] I added an explanation of my changes
* [ ] I have written new tests for my changes, as applicable
* [ ] I successfully ran tests with my changes locally

## Additional notes (optional) 

**Still need to write unit tests.**